### PR TITLE
Fix no attribute 'location' error

### DIFF
--- a/site_map_extractor.py
+++ b/site_map_extractor.py
@@ -410,7 +410,7 @@ class BurpExtender(IBurpExtender, ITab):
                 for j in self.responseHeaders:
                     if j.startswith('Location:'):
                         self.location = j.split(' ')[1]
-                self.tableData.append([self.stripURLPort(self.urlDecode), str(self.referer), str(self.responseCode), self.location])
+                        self.tableData.append([self.stripURLPort(self.urlDecode), str(self.referer), str(self.responseCode), self.location])
 
         dataModel = DefaultTableModel(self.tableData, self.colNames)
         self.uiLogTable = swing.JTable(dataModel)


### PR DESCRIPTION
I got an error that might be due to a `3XX` status code without `Location` resulting in the error:

```Traceback (most recent call last):
  File "/home/zeecka/.BurpSuite/bapps/f991b67d4ef94f3c8692c3edca06583e/site_map_extractor.py", line 413, in exportCodes
    self.tableData.append([self.stripURLPort(self.urlDecode), str(self.referer), str(self.responseCode), self.location])
AttributeError: 'BurpExtender' object has no attribute 'location'
```